### PR TITLE
Update `wgpu` to `26.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,13 @@ repository = "https://github.com/iced-rs/cryoglyph"
 license = "MIT OR Apache-2.0 OR Zlib"
 
 [dependencies]
-wgpu = { version = "25", default-features = false, features = ["wgsl"] }
+wgpu = { version = "26", default-features = false, features = ["wgsl"] }
 etagere = "0.2"
 cosmic-text = "0.14"
 lru = { version = "0.16", default-features = false }
-rustc-hash = "2.0"
+rustc-hash = "2"
 
 [dev-dependencies]
-wgpu = "25"
 winit = "0.30"
 pollster = "0.4"
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ license = "MIT OR Apache-2.0 OR Zlib"
 
 [dependencies]
 wgpu = { version = "25", default-features = false, features = ["wgsl"] }
-etagere = "0.2.15"
+etagere = "0.2"
 cosmic-text = "0.14"
-lru = { version = "0.13", default-features = false }
+lru = { version = "0.16", default-features = false }
 rustc-hash = "2.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,14 @@ repository = "https://github.com/iced-rs/cryoglyph"
 license = "MIT OR Apache-2.0 OR Zlib"
 
 [dependencies]
-wgpu = { version = "24", default-features = false, features = ["wgsl"] }
-etagere = "0.2.10"
+wgpu = { version = "25", default-features = false, features = ["wgsl"] }
+etagere = "0.2.15"
 cosmic-text = "0.14"
-lru = { version = "0.12.1", default-features = false }
+lru = { version = "0.13", default-features = false }
 rustc-hash = "2.0"
 
 [dev-dependencies]
-wgpu = "24"
+wgpu = "25"
 winit = "0.30"
 pollster = "0.4"
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -49,7 +49,7 @@ impl WindowState {
             .await
             .unwrap();
         let (device, queue) = adapter
-            .request_device(&DeviceDescriptor::default(), None)
+            .request_device(&DeviceDescriptor::default())
             .await
             .unwrap();
 

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -203,6 +203,7 @@ impl winit::application::ApplicationHandler for Application {
                         label: None,
                         color_attachments: &[Some(RenderPassColorAttachment {
                             view: &view,
+                            depth_slice: None,
                             resolve_target: None,
                             ops: Operations {
                                 load: LoadOp::Clear(wgpu::Color::BLACK),


### PR DESCRIPTION
This pull request includes updates to dependencies and a minor code change in the `examples/hello-world.rs` file. The most important changes include updating the versions of several dependencies in the `Cargo.toml` file and modifying a method call in the `examples/hello-world.rs` file.

Required for https://github.com/iced-rs/iced/pull/2887

Dependency updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L10-R17): Updated the versions of `wgpu`, `etagere`, and `lru` dependencies.

Code changes:

* [`examples/hello-world.rs`](diffhunk://#diff-84bc7aa01152e14470a43431838b94ddac9d90e415e37853882a7d9b72323c2eL52-R52): Removed an unused argument in the `request_device` method call.